### PR TITLE
[ARQ-1108] - Initial support for client side transaction support. Includ...

### DIFF
--- a/arquillian-service-deployer-spring-common/src/test/java/org/jboss/arquillian/spring/deployer/client/SpringProtocolArchiveProcessorTestCase.java
+++ b/arquillian-service-deployer-spring-common/src/test/java/org/jboss/arquillian/spring/deployer/client/SpringProtocolArchiveProcessorTestCase.java
@@ -64,8 +64,8 @@ public class SpringProtocolArchiveProcessorTestCase {
     }
 
     /**
-     * <p>Tests the {@link org.jboss.arquillian.spring.deployer.client.SpringProtocolArchiveProcessor#process(TestDeployment,
-     * Archive)} method when the test deployment is a JAR archive.</p>
+     * <p>Tests the {@link SpringProtocolArchiveProcessor#process(TestDeployment, Archive)}
+     * method when the test deployment is a JAR archive.</p>
      *
      * @throws Exception if any error occurs
      */

--- a/arquillian-service-integration-spring-3-int-tests/src/test/java/org/jboss/arquillian/spring/testsuite/test/Deployments.java
+++ b/arquillian-service-integration-spring-3-int-tests/src/test/java/org/jboss/arquillian/spring/testsuite/test/Deployments.java
@@ -122,8 +122,9 @@ public final class Deployments {
         return createAppDeployment()
                 .addClasses(JpaEmployeeRepository.class)
                 .addAsWebInfResource("jbossas-ds.xml")
+                .addAsWebInfResource("web.xml")
                 .addAsResource("applicationContext-jpa.xml")
-                .addAsResource("persistence/persitence.xml", "META-INF/persistence.xml")
+                .addAsResource("persistence/persistence.xml", "META-INF/persistence.xml")
                 .addAsResource("persistence/insert.sql", "insert.sql");
     }
 

--- a/arquillian-service-integration-spring-3-int-tests/src/test/java/org/jboss/arquillian/spring/testsuite/test/JpaEmployeeRepositoryTestCase.java
+++ b/arquillian-service-integration-spring-3-int-tests/src/test/java/org/jboss/arquillian/spring/testsuite/test/JpaEmployeeRepositoryTestCase.java
@@ -1,3 +1,19 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.arquillian.spring.testsuite.test;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/arquillian-service-integration-spring-3-int-tests/src/test/resources/applicationContext-jpa.xml
+++ b/arquillian-service-integration-spring-3-int-tests/src/test/resources/applicationContext-jpa.xml
@@ -3,20 +3,20 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd">
+       xmlns:jee="http://www.springframework.org/schema/jee"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+                           http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd">
 
-    <!-- Creates local entity manager factory -->
-    <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalEntityManagerFactoryBean">
-        <property name="persistenceUnitName" value="ArquillianTestUnit"/>
-    </bean>
+    <!-- Lookups the entity manager factory -->
+    <jee:jndi-lookup id="entityManagerFactory" jndi-name="persistence/ArquillianTestUnit"/>
 
     <!-- Enables the declarative transaction support -->
     <tx:annotation-driven transaction-manager="txManager"/>
 
     <!-- Creates transaction manager -->
-    <bean id="txManager" class="org.springframework.orm.jpa.JpaTransactionManager">
-        <property name="entityManagerFactory" ref="entityManagerFactory"/>
-    </bean>
+    <bean id="txManager" class="org.springframework.transaction.jta.JtaTransactionManager"/>
 
     <!-- Scans for the beans definitions -->
     <context:component-scan base-package="org.jboss.arquillian.spring.testsuite.beans.repository.impl"/>

--- a/arquillian-service-integration-spring-3-int-tests/src/test/resources/jbossas-ds.xml
+++ b/arquillian-service-integration-spring-3-int-tests/src/test/resources/jbossas-ds.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasources xmlns="http://www.jboss.org/ironjacamar/schema"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="
-        http://www.jboss.org/ironjacamar/schema
-        http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
+             xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
     <datasource enabled="true"
                 jndi-name="jdbc/ArquillianSpringDataSource"
                 pool-name="EmbeddedH2Pool">

--- a/arquillian-service-integration-spring-3-int-tests/src/test/resources/persistence/persistence.xml
+++ b/arquillian-service-integration-spring-3-int-tests/src/test/resources/persistence/persistence.xml
@@ -2,7 +2,8 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
              version="2.0">
-    <persistence-unit name="ArquillianTestUnit" transaction-type="RESOURCE_LOCAL">
+
+    <persistence-unit name="ArquillianTestUnit" transaction-type="JTA">
         <provider>org.hibernate.ejb.HibernatePersistence</provider>
         <jta-data-source>jdbc/ArquillianSpringDataSource</jta-data-source>
         <class>org.jboss.arquillian.spring.testsuite.beans.model.Employee</class>

--- a/arquillian-service-integration-spring-3-int-tests/src/test/resources/web.xml
+++ b/arquillian-service-integration-spring-3-int-tests/src/test/resources/web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <persistence-unit-ref>
+        <persistence-unit-ref-name>persistence/ArquillianTestUnit</persistence-unit-ref-name>
+        <persistence-unit-name>ArquillianTestUnit</persistence-unit-name>
+    </persistence-unit-ref>
+
+</web-app>

--- a/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionArchiveAppender.java
+++ b/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionArchiveAppender.java
@@ -20,7 +20,7 @@ package org.jboss.arquillian.transaction.spring.client;
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.transaction.spring.container.SpringTransactionRemoteExtension;
-import org.jboss.arquillian.transaction.spring.provider.SpringTransactionProvider;
+import org.jboss.arquillian.transaction.spring.provider.AbstractSpringTransactionProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -42,7 +42,7 @@ public class SpringTransactionArchiveAppender implements AuxiliaryArchiveAppende
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "arquillian-transaction-spring.jar");
 
         archive.addPackage(SpringTransactionRemoteExtension.class.getPackage());
-        archive.addPackage(SpringTransactionProvider.class.getPackage());
+        archive.addPackage(AbstractSpringTransactionProvider.class.getPackage());
 
         archive.addAsServiceProvider(RemoteLoadableExtension.class, SpringTransactionRemoteExtension.class);
 

--- a/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionExtension.java
+++ b/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionExtension.java
@@ -19,6 +19,8 @@ package org.jboss.arquillian.transaction.spring.client;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.transaction.spi.provider.TransactionProvider;
+import org.jboss.arquillian.transaction.spring.container.ContainerSpringTransactionProvider;
 
 /**
  * <p>Registers the transaction extension.</p>
@@ -34,6 +36,10 @@ public class SpringTransactionExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
 
+        // registers the spring archive appender
         builder.service(AuxiliaryArchiveAppender.class, SpringTransactionArchiveAppender.class);
+
+        // registers the transaction provider on the client side for local protocol, embedded containers and so on
+        builder.service(TransactionProvider.class, ContainerSpringTransactionProvider.class);
     }
 }

--- a/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/container/ContainerSpringTransactionProvider.java
+++ b/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/container/ContainerSpringTransactionProvider.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.transaction.spring.container;
+
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.spring.integration.context.RemoteTestScopeApplicationContext;
+import org.jboss.arquillian.spring.integration.context.TestScopeApplicationContext;
+import org.jboss.arquillian.transaction.spring.provider.AbstractSpringTransactionProvider;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * <p>A Spring transaction provider that works with remote container and is able to provide transaction support.</p>
+ *
+ * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
+ * @version $Revision: $
+ */
+public class ContainerSpringTransactionProvider extends AbstractSpringTransactionProvider {
+
+    /**
+     * <p>Instance of application context.</p>
+     */
+    @Inject
+    Instance<RemoteTestScopeApplicationContext> applicationContextInstance;
+
+    /**
+     * <p>Creates new instance of {@link ContainerSpringTransactionProvider}.</p>
+     */
+    public ContainerSpringTransactionProvider() {
+        // empty constructor
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected ApplicationContext getApplicationContext() {
+
+        return applicationContextInstance.get().getApplicationContext();
+    }
+}

--- a/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/container/SpringTransactionRemoteExtension.java
+++ b/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/container/SpringTransactionRemoteExtension.java
@@ -18,7 +18,6 @@
 package org.jboss.arquillian.transaction.spring.container;
 
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
-import org.jboss.arquillian.transaction.spring.provider.SpringTransactionProvider;
 import org.jboss.arquillian.transaction.spi.provider.TransactionProvider;
 
 /**
@@ -35,6 +34,6 @@ public class SpringTransactionRemoteExtension implements RemoteLoadableExtension
     @Override
     public void register(ExtensionBuilder builder) {
 
-        builder.service(TransactionProvider.class, SpringTransactionProvider.class);
+        builder.service(TransactionProvider.class, ContainerSpringTransactionProvider.class);
     }
 }

--- a/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/provider/AbstractSpringTransactionProvider.java
+++ b/arquillian-transaction-spring/src/main/java/org/jboss/arquillian/transaction/spring/provider/AbstractSpringTransactionProvider.java
@@ -16,11 +16,8 @@
  */
 package org.jboss.arquillian.transaction.spring.provider;
 
-import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
-import org.jboss.arquillian.spring.integration.context.RemoteTestScopeApplicationContext;
-import org.jboss.arquillian.spring.integration.context.TestScopeApplicationContext;
 import org.jboss.arquillian.transaction.spi.annotation.TransactionScope;
 import org.jboss.arquillian.transaction.spi.provider.TransactionProvider;
 import org.jboss.arquillian.transaction.spi.test.TransactionalTest;
@@ -35,16 +32,13 @@ import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
  *
  * <p>It delegates all the transaction specific handling to the configured {@link PlatformTransactionManager}.</p>
  *
+ * <p>This class is abstract, the concrete implementation provide means for retrieving the transaction manager from
+ * specific application context.</p>
+ *
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  * @version $Revision: $
  */
-public class SpringTransactionProvider implements TransactionProvider {
-
-    /**
-     * <p>Instance of application context.</p>
-     */
-    @Inject
-    Instance<RemoteTestScopeApplicationContext> applicationContextInstance;
+public abstract class AbstractSpringTransactionProvider implements TransactionProvider {
 
     /**
      * <p>Instance of {@link PlatformTransactionManager} to which all the operations are delegated.</p>
@@ -136,9 +130,5 @@ public class SpringTransactionProvider implements TransactionProvider {
      *
      * @return the application context
      */
-    private ApplicationContext getApplicationContext() {
-
-        TestScopeApplicationContext testScopeApplicationContext = applicationContextInstance.get();
-        return testScopeApplicationContext.getApplicationContext();
-    }
+    protected abstract ApplicationContext getApplicationContext();
 }

--- a/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionArchiveAppenderTestCase.java
+++ b/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionArchiveAppenderTestCase.java
@@ -14,11 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.spring.integration.transaction.client;
+package org.jboss.arquillian.transaction.spring.client;
 
 import org.jboss.arquillian.transaction.spring.container.SpringTransactionRemoteExtension;
-import org.jboss.arquillian.transaction.spring.provider.SpringTransactionProvider;
-import org.jboss.arquillian.transaction.spring.client.SpringTransactionArchiveAppender;
+import org.jboss.arquillian.transaction.spring.provider.AbstractSpringTransactionProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
@@ -48,7 +47,7 @@ public class SpringTransactionArchiveAppenderTestCase {
      * <p>Represents the list of required classes.</p>
      */
     private final static List<Class<?>> REQUIRED_CLASSES = Arrays.asList(SpringTransactionRemoteExtension.class,
-            SpringTransactionProvider.class);
+            AbstractSpringTransactionProvider.class);
 
     /**
      * <p>Sets up the test environment.</p>

--- a/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionExtensionTestCase.java
+++ b/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/client/SpringTransactionExtensionTestCase.java
@@ -14,30 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.spring.integration.transaction.container;
+package org.jboss.arquillian.transaction.spring.client;
 
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.transaction.spring.provider.SpringTransactionProvider;
 import org.jboss.arquillian.transaction.spi.provider.TransactionProvider;
-import org.jboss.arquillian.transaction.spring.container.SpringTransactionRemoteExtension;
+import org.jboss.arquillian.transaction.spring.container.ContainerSpringTransactionProvider;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 /**
- * <p>Tests {@link org.jboss.arquillian.transaction.spring.container.SpringTransactionRemoteExtension} class.</p>
+ * <p>Tests {@link org.jboss.arquillian.transaction.spring.client.SpringTransactionExtension} class.</p>
  *
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
-public class SpringTransactionRemoteExtensionTestCase {
+public class SpringTransactionExtensionTestCase {
 
     /**
      * <p>Represents the instance of tested class.</p>
      */
-    private SpringTransactionRemoteExtension instance;
+    private SpringTransactionExtension instance;
 
     /**
      * <p>Sets up the test environment.</p>
@@ -45,11 +43,11 @@ public class SpringTransactionRemoteExtensionTestCase {
     @Before
     public void setUp() {
 
-        instance = new SpringTransactionRemoteExtension();
+        instance = new SpringTransactionExtension();
     }
 
     /**
-     * <p>Tests the {@link SpringTransactionRemoteExtension#register(LoadableExtension.ExtensionBuilder)} method.</p>
+     * <p>Tests the {@link SpringTransactionExtension#register(LoadableExtension.ExtensionBuilder)} method.</p>
      */
     @Test
     public void testRegister() {
@@ -58,7 +56,8 @@ public class SpringTransactionRemoteExtensionTestCase {
 
         instance.register(mockExtensionBuilder);
 
-        verify(mockExtensionBuilder).service(TransactionProvider.class, SpringTransactionProvider.class);
+        verify(mockExtensionBuilder).service(AuxiliaryArchiveAppender.class, SpringTransactionArchiveAppender.class);
+        verify(mockExtensionBuilder).service(TransactionProvider.class, ContainerSpringTransactionProvider.class);
         verifyNoMoreInteractions(mockExtensionBuilder);
     }
 }

--- a/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/container/ContainerSpringTransactionProviderTestCase.java
+++ b/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/container/ContainerSpringTransactionProviderTestCase.java
@@ -1,29 +1,12 @@
-/*
- * JBoss, Home of Professional Open Source
- * Copyright 2012, Red Hat Middleware LLC, and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.jboss.arquillian.spring.integration.transaction.provider;
+package org.jboss.arquillian.transaction.spring.container;
 
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.spring.integration.context.RemoteTestScopeApplicationContext;
-import org.jboss.arquillian.spring.integration.context.TestScopeApplicationContext;
-import org.jboss.arquillian.spring.integration.transaction.utils.TestReflectionHelper;
 import org.jboss.arquillian.transaction.api.annotation.Transactional;
 import org.jboss.arquillian.transaction.impl.test.TransactionalTestImpl;
-import org.jboss.arquillian.transaction.spring.provider.SpringTransactionProvider;
+import org.jboss.arquillian.transaction.spring.provider.AbstractSpringTransactionProvider;
+import org.jboss.arquillian.transaction.spring.utils.TestReflectionHelper;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -31,25 +14,23 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 /**
- * <p>Tests {@link org.jboss.arquillian.transaction.spring.provider.SpringTransactionProvider} class.</p>
+ * <p>Tests {@link ContainerSpringTransactionProvider} class.</p>
  *
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
-public class SpringTransactionProviderTestCase {
+public class ContainerSpringTransactionProviderTestCase {
 
     /**
      * <p>Represents the instance of tested class.</p>
      */
-    private SpringTransactionProvider instance;
+    private AbstractSpringTransactionProvider instance;
 
     /**
-     * <p>Mock instance of {@link TestScopeApplicationContext}.</p>
+     * <p>Mock instance of {@link RemoteTestScopeApplicationContext}.</p>
      */
     private Instance<RemoteTestScopeApplicationContext> mockTestScopeApplicationContextInstance;
 
@@ -86,7 +67,7 @@ public class SpringTransactionProviderTestCase {
     @Before
     public void setUp() throws Exception {
 
-        instance = new SpringTransactionProvider();
+        instance = new ContainerSpringTransactionProvider();
 
         mockApplicationContext = mock(ApplicationContext.class);
         mockPlatformTransactionManager = mock(PlatformTransactionManager.class);
@@ -104,13 +85,15 @@ public class SpringTransactionProviderTestCase {
         mockPlatformTransactionManagerInstance = mock(InstanceProducer.class);
         mockTransactionStatusInstance = mock(InstanceProducer.class);
 
-        TestReflectionHelper.setFieldValue(instance, "applicationContextInstance", mockTestScopeApplicationContextInstance);
-        TestReflectionHelper.setFieldValue(instance, "transactionManagerInstance", mockPlatformTransactionManagerInstance);
+        TestReflectionHelper.setFieldValue(instance, "applicationContextInstance",
+                mockTestScopeApplicationContextInstance);
+        TestReflectionHelper.setFieldValue(instance, "transactionManagerInstance",
+                mockPlatformTransactionManagerInstance);
         TestReflectionHelper.setFieldValue(instance, "transactionStatusInstance", mockTransactionStatusInstance);
     }
 
     /**
-     * <p>Tests the {@link SpringTransactionProvider#
+     * <p>Tests the {@link AbstractSpringTransactionProvider#
      * beginTransaction(org.jboss.arquillian.transaction.spi.test.TransactionalTest)} method.</p>
      */
     @Test
@@ -124,8 +107,8 @@ public class SpringTransactionProviderTestCase {
     }
 
     /**
-     * <p>Tests the {@link SpringTransactionProvider#
-     * rollbackTransaction(org.jboss.arquillian.transaction.spi.test.TransactionalTest)} method.</p>
+     * <p>Tests the {@link AbstractSpringTransactionProvider#rollbackTransaction(
+     * org.jboss.arquillian.transaction.spi.test.TransactionalTest)} method.</p>
      */
     @Test
     public void testRollbackTransaction() {
@@ -139,8 +122,8 @@ public class SpringTransactionProviderTestCase {
     }
 
     /**
-     * <p>Tests the {@link SpringTransactionProvider#
-     * commitTransaction(org.jboss.arquillian.transaction.spi.test.TransactionalTest)} method.</p>
+     * <p>Tests the {@link AbstractSpringTransactionProvider#
+     * commitTransaction(org.jboss.arquillian.transaction.spi.test.TransactionalTest)}method.</p>
      */
     @Test
     public void testCommitTransaction() {

--- a/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/container/SpringTransactionRemoteExtensionTestCase.java
+++ b/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/container/SpringTransactionRemoteExtensionTestCase.java
@@ -14,30 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.spring.integration.transaction.client;
+package org.jboss.arquillian.transaction.spring.container;
 
-import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.transaction.spring.client.SpringTransactionArchiveAppender;
-import org.jboss.arquillian.transaction.spring.client.SpringTransactionExtension;
+import org.jboss.arquillian.transaction.spi.provider.TransactionProvider;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 /**
- * <p>Tests {@link org.jboss.arquillian.transaction.spring.client.SpringTransactionExtension} class.</p>
+ * <p>Tests {@link org.jboss.arquillian.transaction.spring.container.SpringTransactionRemoteExtension} class.</p>
  *
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
-public class SpringTransactionExtensionTestCase {
+public class SpringTransactionRemoteExtensionTestCase {
 
     /**
      * <p>Represents the instance of tested class.</p>
      */
-    private SpringTransactionExtension instance;
+    private SpringTransactionRemoteExtension instance;
 
     /**
      * <p>Sets up the test environment.</p>
@@ -45,11 +41,11 @@ public class SpringTransactionExtensionTestCase {
     @Before
     public void setUp() {
 
-        instance = new SpringTransactionExtension();
+        instance = new SpringTransactionRemoteExtension();
     }
 
     /**
-     * <p>Tests the {@link SpringTransactionExtension#register(LoadableExtension.ExtensionBuilder)} method.</p>
+     * <p>Tests the {@link SpringTransactionRemoteExtension#register(LoadableExtension.ExtensionBuilder)} method.</p>
      */
     @Test
     public void testRegister() {
@@ -58,7 +54,7 @@ public class SpringTransactionExtensionTestCase {
 
         instance.register(mockExtensionBuilder);
 
-        verify(mockExtensionBuilder).service(AuxiliaryArchiveAppender.class, SpringTransactionArchiveAppender.class);
+        verify(mockExtensionBuilder).service(TransactionProvider.class, ContainerSpringTransactionProvider.class);
         verifyNoMoreInteractions(mockExtensionBuilder);
     }
 }

--- a/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/utils/TestReflectionHelper.java
+++ b/arquillian-transaction-spring/src/test/java/org/jboss/arquillian/transaction/spring/utils/TestReflectionHelper.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.jboss.arquillian.spring.integration.transaction.utils;
+package org.jboss.arquillian.transaction.spring.utils;
 
 import java.lang.reflect.Field;
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <version.arquillian_warp>1.0.0.Alpha2</version.arquillian_warp>
 
         <!-- Arquillian Transaction -->
-        <version.arquillian_transaction>1.0.0.Alpha1</version.arquillian_transaction>
+        <version.arquillian_transaction>1.0.0.Alpha3</version.arquillian_transaction>
 
         <!-- Test Dependencies -->
         <version.junit_junit>4.8.1</version.junit_junit>
@@ -202,6 +202,7 @@
                 <artifactId>validation-api</artifactId>
                 <version>1.0.0.GA</version>
             </dependency>
+
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>


### PR DESCRIPTION
...es both embedded (local protocol) containers support and running the transaction methods from client side.

I also updated the Transaction Extension to Alpha 3 and had to upgrate the Arq Core to 1.0.3. Without that the test were failling. Does the transaction extension use that version?
