### PR TITLE
Fixed AnnotatedRemoteConfigurationDefaultConfigTestCase

### DIFF
--- a/arquillian-service-integration-spring-3-int-tests/src/test/java/org/jboss/arquillian/spring/testsuite/test/AnnotatedRemoteConfigurationDefaultConfigTestCase.java
+++ b/arquillian-service-integration-spring-3-int-tests/src/test/java/org/jboss/arquillian/spring/testsuite/test/AnnotatedRemoteConfigurationDefaultConfigTestCase.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
 @SpringAnnotationConfiguration
-@RunAsClient
 public class AnnotatedRemoteConfigurationDefaultConfigTestCase {
     @Autowired
     EmployeeService employeeService;


### PR DESCRIPTION
...nConfiguration

what: fixing failed test AnnotatedRemoteConfigurationDefaultConfigTestCase
why: @RunAsClient annotation was wrongly added
