### PR TITLE
Corrected the warp provider implementation for Java 1.6.

### DIFF
--- a/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/SpringWarpTestEnricher.java
+++ b/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/SpringWarpTestEnricher.java
@@ -25,7 +25,7 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -41,7 +41,7 @@ public class SpringWarpTestEnricher implements TestEnricher {
      * <p>Instance of {@link javax.servlet.ServletRequest}.</p>
      */
     @Inject
-    private Instance<ServletRequest> servletRequest;
+    private Instance<HttpServletRequest> servletRequest;
 
     /**
      * {@inheritDoc}

--- a/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/provider/AbstractWarpGenericResourceProvider.java
+++ b/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/provider/AbstractWarpGenericResourceProvider.java
@@ -23,34 +23,19 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import org.jboss.arquillian.warp.extension.spring.SpringMvcResult;
 import org.jboss.arquillian.warp.extension.spring.container.Commons;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 
 /**
  * <p>A base resource provider that adds generic capabilities for all concrete providers.</p>
  *
+ * <p>This class defines {@link #getProvidedResourceClass()} that is able to retrieve the class of the provided class
+ * directly from the class hierarchy. The implementing class must specify the concrete class.</p>
+ *
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
-public abstract class AbstractWarpGenericResourceProvider<T> implements ResourceProvider {
-
-    /**
-     * <p>The injected {@link SpringMvcResult} class.</p>
-     */
-    @Inject
-    private Instance<ServletRequest> servletRequestInstance;
-
-    /**
-     * <p>Retrieves the {@link SpringMvcResult} class.</p>
-     *
-     * <p>The default implementation retrieves the generic type from the class hierarchy.</p>
-     *
-     * @return the {@link SpringMvcResult}
-     */
-    protected SpringMvcResult getSpringMvcResult() {
-
-        return (SpringMvcResult) servletRequestInstance.get().getAttribute(Commons.SPRING_MVC_RESULT_ATTRIBUTE_NAME);
-    }
+public abstract class AbstractWarpGenericResourceProvider<T> extends AbstractWarpResourceProvider<T> {
 
     /**
      * <p>Retrieves the provided class from the generic base type.</p>
@@ -62,23 +47,4 @@ public abstract class AbstractWarpGenericResourceProvider<T> implements Resource
 
         return (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-
-        return internalLookup(resource, qualifiers);
-    }
-
-    /**
-     * <p>Retrieves the resource instance provided by this class.</p>
-     *
-     * @param resource   the resource information
-     * @param qualifiers the additional qualifiers specified for this type
-     *
-     * @return the resource instance
-     */
-    protected abstract T internalLookup(ArquillianResource resource, Annotation... qualifiers);
 }

--- a/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/provider/AbstractWarpResourceProvider.java
+++ b/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/provider/AbstractWarpResourceProvider.java
@@ -1,0 +1,77 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.warp.extension.spring.container.provider;
+
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+import org.jboss.arquillian.warp.extension.spring.SpringMvcResult;
+import org.jboss.arquillian.warp.extension.spring.container.Commons;
+
+import javax.servlet.http.HttpServletRequest;
+import java.lang.annotation.Annotation;
+
+/**
+ * <p>A generic implementation of the {@link ResourceProvider} that can handle concrete strongly typed resource.</p>
+ *
+ * <p>The provided resource can be lookup through {@link @ArquillianResource}.</p>
+ *
+ * <p>The implementation of this class should override the {@link #internalLookup(ArquillianResource, Annotation...)}
+ * method in order to be able lookup resource.</p>
+ *
+ * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
+ */
+public abstract class AbstractWarpResourceProvider<T> implements ResourceProvider {
+
+    /**
+     * <p>The injected {@link SpringMvcResult} class.</p>
+     */
+    @Inject
+    private Instance<HttpServletRequest> servletRequestInstance;
+
+    /**
+     * <p>Retrieves the {@link SpringMvcResult} class.</p>
+     *
+     * <p>The default implementation retrieves the generic type from the class hierarchy.</p>
+     *
+     * @return the {@link SpringMvcResult}
+     */
+    protected SpringMvcResult getSpringMvcResult() {
+
+        return (SpringMvcResult) servletRequestInstance.get().getAttribute(Commons.SPRING_MVC_RESULT_ATTRIBUTE_NAME);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+
+        return internalLookup(resource, qualifiers);
+    }
+
+    /**
+     * <p>Retrieves the resource instance provided by this class.</p>
+     *
+     * @param resource   the resource information
+     * @param qualifiers the additional qualifiers specified for this type
+     *
+     * @return the resource instance
+     */
+    protected abstract T internalLookup(ArquillianResource resource, Annotation... qualifiers);
+}

--- a/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/provider/HandlerInterceptorsProvider.java
+++ b/arquillian-warp-spring/src/main/java/org/jboss/arquillian/warp/extension/spring/container/provider/HandlerInterceptorsProvider.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Annotation;
  *
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
-public class HandlerInterceptorsProvider extends AbstractWarpGenericResourceProvider<HandlerInterceptor[]> {
+public class HandlerInterceptorsProvider extends AbstractWarpResourceProvider<HandlerInterceptor[]> {
 
     /**
      * {@inheritDoc}
@@ -34,7 +34,7 @@ public class HandlerInterceptorsProvider extends AbstractWarpGenericResourceProv
     @Override
     public boolean canProvide(Class<?> aClass) {
 
-        return getProvidedResourceClass().equals(aClass)
+        return HandlerInterceptor[].class.isAssignableFrom(aClass)
                 && getSpringMvcResult().getInterceptors() != null;
     }
 

--- a/arquillian-warp-spring/src/test/java/org/jboss/arquillian/warp/extension/spring/container/SpringWarpTestEnricherTestCase.java
+++ b/arquillian-warp-spring/src/test/java/org/jboss/arquillian/warp/extension/spring/container/SpringWarpTestEnricherTestCase.java
@@ -26,6 +26,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -106,10 +107,10 @@ public class SpringWarpTestEnricherTestCase {
      */
     private void setSpringMvcResult(SpringMvcResult springMvcResult) throws Exception {
 
-        ServletRequest mockServletRequest = mock(ServletRequest.class);
+        HttpServletRequest mockServletRequest = mock(HttpServletRequest.class);
         when(mockServletRequest.getAttribute(Commons.SPRING_MVC_RESULT_ATTRIBUTE_NAME)).thenReturn(springMvcResult);
 
-        Instance<ServletRequest> mockServletRequestInstance = mock(Instance.class);
+        Instance<HttpServletRequest> mockServletRequestInstance = mock(Instance.class);
         TestReflectionHelper.setFieldValue(instance, "servletRequest", mockServletRequestInstance);
         when(mockServletRequestInstance.get()).thenReturn(mockServletRequest);
     }

--- a/arquillian-warp-spring/src/test/java/org/jboss/arquillian/warp/extension/spring/container/provider/ProviderBaseTestCase.java
+++ b/arquillian-warp-spring/src/test/java/org/jboss/arquillian/warp/extension/spring/container/provider/ProviderBaseTestCase.java
@@ -26,6 +26,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -82,10 +83,10 @@ public class ProviderBaseTestCase {
     @SuppressWarnings("unchecked")
     protected void setSpringMvcResult() throws Exception {
 
-        ServletRequest mockServletRequest = mock(ServletRequest.class);
+        HttpServletRequest mockServletRequest = mock(HttpServletRequest.class);
         when(mockServletRequest.getAttribute(Commons.SPRING_MVC_RESULT_ATTRIBUTE_NAME)).thenReturn(springMvcResult);
 
-        Instance<ServletRequest> mockServletRequestInstance = mock(Instance.class);
+        Instance<HttpServletRequest> mockServletRequestInstance = mock(Instance.class);
         TestReflectionHelper.setFieldValue(instance, "servletRequestInstance", mockServletRequestInstance);
         when(mockServletRequestInstance.get()).thenReturn(mockServletRequest);
     }


### PR DESCRIPTION
The newly added implementation of AbstractWarpGenericResourceProvider was causing an runtime error in Java 1.6

This pull request corrects this.
